### PR TITLE
Dockerのbaseイメージをubuntuからalpineに変更した

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM ubuntu:18.04 as builder
+FROM alpine as builder
 MAINTAINER hidekuno@gmail.com
 
 # setting 
 ENV HOME /root
 WORKDIR $HOME
 
-RUN apt-get update && apt-get install -y python3 sqlite3 git|true
+RUN apk --update add python3 git sqlite|true
 RUN git clone https://github.com/hidekuno/cidr-lite && python3 ${HOME}/cidr-lite/cidr_create.py >cidr.txt |true
 RUN sqlite3 database.cidr '.read /root/cidr-lite/init.sql'
 
-FROM ubuntu:18.04 as cidr-lite
+FROM alpine as cidr-lite
 MAINTAINER hidekuno@gmail.com
 
-RUN apt-get update && apt-get -y install python3 sqlite3
+RUN apk --update add python3
 COPY --from=builder /root/database.cidr /root/
 COPY --from=builder /root/cidr-lite/cidr_create.py /root/
 COPY --from=builder /root/cidr-lite/cidr_search.py /root/


### PR DESCRIPTION
イメージサイズを縮小化するため
```
macbookair:cidr-lite hideki$ docker images
REPOSITORY            TAG                 IMAGE ID            CREATED             SIZE
hidekuno/cidr-lite    latest              ecca07c11251        11 minutes ago      82.7MB
```