### PR TITLE
未定義エラー対応

### DIFF
--- a/cidr_search.py
+++ b/cidr_search.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         cursor.execute("PRAGMA case_sensitive_like=ON;")
 
         if args.ipaddr:
-            do_eval_ipaddr(ipaddr,cursor)
+            do_eval_ipaddr(args.ipaddr,cursor)
         else:
             repl(cursor)
         conn.close()
@@ -88,5 +88,5 @@ if __name__ == "__main__":
     except EOFError:
         sys.exit(0)
     except Exception as e:
-        traceback.print_exc()
+        print(e, traceback.format_exc(), file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
```
# python3 cidr_search.py --ip 182.22.28.252
Traceback (most recent call last):
  File "cidr_search.py", line 83, in <module>
    do_eval_ipaddr(ipaddr,cursor)
NameError: name 'ipaddr' is not defined
#
```