### PR TITLE
pyflakesで摘出したエラーに対応した

### DIFF
--- a/cidr_create_easy.py
+++ b/cidr_create_easy.py
@@ -5,6 +5,7 @@
 # hidekuno@gmail.com
 #
 import sys
+import traceback
 import gzip
 import urllib.request
 from io import StringIO
@@ -33,4 +34,5 @@ if __name__ == "__main__":
             print(addr + "\t" + mask + "\t" + subnet + "\t" + country)
 
     except Exception as e:
-        traceback.print_exc()
+        print(e, traceback.format_exc(), file=sys.stderr)
+        sys.exit(1)

--- a/cidr_create_rir.py
+++ b/cidr_create_rir.py
@@ -5,6 +5,7 @@
 # hidekuno@gmail.com
 #
 import sys
+import traceback
 import ipaddress
 import urllib.request
 
@@ -42,4 +43,5 @@ if __name__ == "__main__":
             make_data(r)
             sys.stderr.write("done. \n")
     except Exception as e:
-        traceback.print_exc()
+        print(e, traceback.format_exc(), file=sys.stderr)
+        sys.exit(1)

--- a/tests/cidr_search_test.py
+++ b/tests/cidr_search_test.py
@@ -10,6 +10,7 @@
 # 3) PYTHONPATH=$HOME/jvn python tests/cidr_search_test.py
 #
 import unittest
+import traceback
 import os
 import sqlite3
 from pathlib import Path
@@ -37,26 +38,26 @@ class TestMethods(unittest.TestCase):
 
     def test_ipaddr_private(self):
         try:
-            r = eval_ipaddr('192.168.1.1',self.cursor)
+            eval_ipaddr('192.168.1.1',self.cursor)
         except Exception as e:
             self.assertEqual(str(e), 'Private IP address')
 
     def test_ipaddr_noip(self):
         try:
-            r = eval_ipaddr('999.999.999.999',self.cursor)
+            eval_ipaddr('999.999.999.999',self.cursor)
         except Exception as e:
             self.assertEqual(str(e), 'Not IP address')
 
     def test_ipaddr_alphabet(self):
         try:
-            r = eval_ipaddr('aaa.bbb.ccc.ddd',self.cursor)
+            eval_ipaddr('aaa.bbb.ccc.ddd',self.cursor)
         except Exception as e:
             self.assertEqual(str(e), 'Not IP address')
 
     def test_ipaddr_notfound(self):
         # class D
         try:
-            r = eval_ipaddr('224.1.1.255',self.cursor)
+            eval_ipaddr('224.1.1.255',self.cursor)
         except Exception as e:
             self.assertEqual(str(e), 'Not Found')
 
@@ -65,5 +66,5 @@ if __name__ == '__main__':
         unittest.main()
 
     except Exception as e:
-        traceback.print_exc()
+        print(e, traceback.format_exc(), file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
pyflakesの結果
```
./tests/cidr_search_test.py:40:13 local variable 'r' is assigned to but never used
./tests/cidr_search_test.py:46:13 local variable 'r' is assigned to but never used
./tests/cidr_search_test.py:52:13 local variable 'r' is assigned to but never used
./tests/cidr_search_test.py:59:13 local variable 'r' is assigned to but never used
./tests/cidr_search_test.py:67:5 local variable 'e' is assigned to but never used
./tests/cidr_search_test.py:68:9 undefined name 'traceback'
./cidr_create_easy.py:7:1 'sys' imported but unused
./cidr_create_easy.py:35:5 local variable 'e' is assigned to but never used
./cidr_create_easy.py:36:9 undefined name 'traceback'
./cidr_create_rir.py:44:5 local variable 'e' is assigned to but never used
./cidr_create_rir.py:45:9 undefined name 'traceback'
```